### PR TITLE
화면 회전시 발생하는 이슈 해결 - 페이징 전용 클래스 구현

### DIFF
--- a/app/src/main/java/github/dev_playground/jeju_road/data/api/RestaurantApi.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/data/api/RestaurantApi.kt
@@ -1,14 +1,14 @@
 package github.dev_playground.jeju_road.data.api
 
+import github.dev_playground.jeju_road.data.model.Restaurant
 import github.dev_playground.jeju_road.data.model.RestaurantDetail
-import github.dev_playground.jeju_road.data.model.Restaurants
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface RestaurantApi {
     @GET("restaurants")
-    suspend fun getRestaurantList(@Query("page") param: Int): Restaurants
+    suspend fun getRestaurantList(@Query("page") param: Int): Restaurant
 
     @GET("restaurants/{id}")
     suspend fun getRestaurantDetail(@Path("id") id: Long): RestaurantDetail

--- a/app/src/main/java/github/dev_playground/jeju_road/data/api/mock/MockRestaurantApi.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/data/api/mock/MockRestaurantApi.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.google.gson.Gson
 import github.dev_playground.jeju_road.data.api.RestaurantApi
 import github.dev_playground.jeju_road.data.model.RestaurantDetail
-import github.dev_playground.jeju_road.data.model.Restaurants
+import github.dev_playground.jeju_road.data.model.Restaurant
 import github.dev_playground.jeju_road.util.loadAsset
 
 class MockRestaurantApi(
@@ -13,8 +13,8 @@ class MockRestaurantApi(
 
     private val gson = Gson()
 
-    override suspend fun getRestaurantList(param: Int): Restaurants {
-        return gson.fromJson(context.loadAsset("restaurant.json"), Restaurants::class.java)
+    override suspend fun getRestaurantList(param: Int): Restaurant {
+        return gson.fromJson(context.loadAsset("restaurant.json"), Restaurant::class.java)
     }
 
     override suspend fun getRestaurantDetail(id: Long): RestaurantDetail {

--- a/app/src/main/java/github/dev_playground/jeju_road/data/model/Restaurant.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/data/model/Restaurant.kt
@@ -1,0 +1,10 @@
+package github.dev_playground.jeju_road.data.model
+
+data class Restaurant(
+    val message: String,
+    val information: Information
+)
+
+fun Restaurant?.isNotNullOrEmpty(): Boolean {
+    return this != null && information.contentList.isNotEmpty()
+}

--- a/app/src/main/java/github/dev_playground/jeju_road/data/model/Restaurants.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/data/model/Restaurants.kt
@@ -1,6 +1,0 @@
-package github.dev_playground.jeju_road.data.model
-
-data class Restaurants(
-    val message: String,
-    val information: Information
-)

--- a/app/src/main/java/github/dev_playground/jeju_road/data/repository/RestaurantRepository.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/data/repository/RestaurantRepository.kt
@@ -1,11 +1,11 @@
 package github.dev_playground.jeju_road.data.repository
 
 import github.dev_playground.jeju_road.data.model.RestaurantDetail
-import github.dev_playground.jeju_road.data.model.Restaurants
+import github.dev_playground.jeju_road.data.model.Restaurant
 
 interface RestaurantRepository {
 
-    suspend fun getRestaurantList(page: Int): Restaurants
+    suspend fun getRestaurantList(page: Int): Restaurant
 
     suspend fun getRestaurantDetail(id: Long): RestaurantDetail
 

--- a/app/src/main/java/github/dev_playground/jeju_road/data/repository/RestaurantRepositoryImpl.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/data/repository/RestaurantRepositoryImpl.kt
@@ -2,13 +2,13 @@ package github.dev_playground.jeju_road.data.repository
 
 import github.dev_playground.jeju_road.data.api.RestaurantApi
 import github.dev_playground.jeju_road.data.model.RestaurantDetail
-import github.dev_playground.jeju_road.data.model.Restaurants
+import github.dev_playground.jeju_road.data.model.Restaurant
 
 class RestaurantRepositoryImpl(
     private val restaurantApi: RestaurantApi
 ): RestaurantRepository {
 
-    override suspend fun getRestaurantList(page: Int): Restaurants {
+    override suspend fun getRestaurantList(page: Int): Restaurant {
         return runCatching {
             restaurantApi.getRestaurantList(page)
         }.getOrThrow()

--- a/app/src/main/java/github/dev_playground/jeju_road/domain/usecase/GetRestaurantListUseCase.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/domain/usecase/GetRestaurantListUseCase.kt
@@ -1,15 +1,15 @@
 package github.dev_playground.jeju_road.domain.usecase
 
-import github.dev_playground.jeju_road.data.model.Restaurants
+import github.dev_playground.jeju_road.data.model.Restaurant
 import github.dev_playground.jeju_road.data.repository.RestaurantRepository
 import kotlinx.coroutines.CoroutineDispatcher
 
 class GetRestaurantListUseCase(
     private val restaurantRepository: RestaurantRepository,
     ioDispatcher: CoroutineDispatcher
-) : CoroutineUseCase<Int, Restaurants>(ioDispatcher) {
+) : CoroutineUseCase<Int, Restaurant>(ioDispatcher) {
 
-    override suspend fun execute(param: Int): Restaurants {
+    override suspend fun execute(param: Int): Restaurant {
         return restaurantRepository.getRestaurantList(param)
     }
 

--- a/app/src/main/java/github/dev_playground/jeju_road/ui/list/RestaurantListFragment.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/ui/list/RestaurantListFragment.kt
@@ -26,13 +26,14 @@ class RestaurantListFragment : BaseFragment<FragmentRestaurantListBinding>(
         setUpView()
 
         viewModel.apply {
-            restaurantList.observe {
-                loadingEventViewModel.setLoadingState(it) { restaurants ->
+            restaurantState.observe {
+                loadingEventViewModel.setLoadingState(it) { restaurant ->
                     binding.swipeRefreshLayoutRestaurantList.isRefreshing = false
-
-                    val list = restaurantListAdapter.currentList + restaurants.information.contentList
-                    restaurantListAdapter.submitList(list)
+                    addContentList(restaurant.information.contentList)
                 }
+            }
+            contentList.observe {
+                restaurantListAdapter.submitList(it)
             }
             onRestaurantClickEvent.eventObserve {
                 requireActivity().startActivity<RestaurantPageActivity> {
@@ -52,8 +53,7 @@ class RestaurantListFragment : BaseFragment<FragmentRestaurantListBinding>(
             }
 
             swipeRefreshLayoutRestaurantList.setOnRefreshListener {
-                restaurantListAdapter.submitList(null)
-                viewModel.refreshPageIndex()
+                viewModel.refreshContentList()
             }
         }
     }
@@ -66,8 +66,10 @@ class RestaurantListFragment : BaseFragment<FragmentRestaurantListBinding>(
                 val lastVisibleItemPosition = layoutManager.findLastCompletelyVisibleItemPosition()
                 val itemTotalCount = restaurantListAdapter.itemCount.minus(1)
 
-                if (lastVisibleItemPosition == itemTotalCount) {
-                    viewModel.incrementPageIndex()
+                if (lastVisibleItemPosition == itemTotalCount &&
+                    !binding.swipeRefreshLayoutRestaurantList.isRefreshing
+                ) {
+                    viewModel.fetchRestaurant()
                 }
             }
         }

--- a/app/src/main/java/github/dev_playground/jeju_road/ui/list/RestaurantListViewModel.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/ui/list/RestaurantListViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import github.dev_playground.jeju_road.data.model.Content
-import github.dev_playground.jeju_road.data.model.Restaurants
+import github.dev_playground.jeju_road.data.model.Restaurant
+import github.dev_playground.jeju_road.data.model.isNotNullOrEmpty
 import github.dev_playground.jeju_road.domain.usecase.GetRestaurantListUseCase
 import github.dev_playground.jeju_road.util.Event
+import github.dev_playground.jeju_road.util.Pager
 import github.dev_playground.jeju_road.util.UiState
 import github.dev_playground.jeju_road.util.toUiState
 import kotlinx.coroutines.launch
@@ -16,40 +18,45 @@ class RestaurantListViewModel(
     private val getRestaurantListUseCase: GetRestaurantListUseCase
 ) : ViewModel() {
 
-    private val _page: MutableLiveData<Int> = MutableLiveData(START_PAGE_INDEX)
-    val page: LiveData<Int> = _page
+    private val pager = Pager()
 
-    private val _restaurantList: MutableLiveData<UiState<Restaurants>> = MutableLiveData<UiState<Restaurants>>(UiState.loading())
-    val restaurantList: LiveData<UiState<Restaurants>> = _restaurantList
+    private val _restaurantState: MutableLiveData<UiState<Restaurant>> = MutableLiveData()
+    val restaurantState: LiveData<UiState<Restaurant>> = _restaurantState
+
+    private val _contentList: MutableLiveData<List<Content>> = MutableLiveData(emptyList())
+    val contentList: LiveData<List<Content>> = _contentList
 
     private val _onRestaurantClickEvent =  MutableLiveData<Event<Content>>()
     val onRestaurantClickEvent: LiveData<Event<Content>> = _onRestaurantClickEvent
 
     init {
-        fetchRestaurantList()
+        fetchRestaurant()
     }
 
-    private fun fetchRestaurantList() = viewModelScope.launch {
-        val param = page.value ?: START_PAGE_INDEX
-        _restaurantList.value = getRestaurantListUseCase.invoke(param).toUiState()
+    fun fetchRestaurant() {
+        viewModelScope.launch {
+            pager.load { param ->
+                val result = getRestaurantListUseCase.invoke(param).toUiState()
+                _restaurantState.value = result
+
+                result.data?.isNotNullOrEmpty()
+            }
+        }
     }
 
-    fun incrementPageIndex() = viewModelScope.launch {
-        _page.value = _page.value?.plus(1) ?: START_PAGE_INDEX
-        fetchRestaurantList()
+    fun addContentList(contentList: List<Content>) {
+        _contentList.value = (_contentList.value ?: emptyList()) + contentList
     }
 
-    fun refreshPageIndex() {
-        _page.value = START_PAGE_INDEX
-        fetchRestaurantList()
+
+    fun refreshContentList() {
+        _contentList.value = emptyList()
+        pager.reset()
+        fetchRestaurant()
     }
 
     fun callOnRestaurantClickEvent(data: Content) {
         _onRestaurantClickEvent.value = Event(data)
-    }
-
-    companion object {
-        private const val START_PAGE_INDEX = 0
     }
 
 }

--- a/app/src/main/java/github/dev_playground/jeju_road/util/Pager.kt
+++ b/app/src/main/java/github/dev_playground/jeju_road/util/Pager.kt
@@ -1,0 +1,27 @@
+package github.dev_playground.jeju_road.util
+
+class Pager {
+
+    private var pageIndex = START_PAGE_INDEX
+
+    suspend fun load(predicate: suspend (Int) -> Boolean?) {
+        val isSuccess = predicate(pageIndex)
+
+        if (isSuccess == true) {
+            increment()
+        }
+    }
+
+    private fun increment() {
+        pageIndex++
+    }
+
+    fun reset() {
+        pageIndex = START_PAGE_INDEX
+    }
+
+    companion object {
+        private const val START_PAGE_INDEX = 0
+    }
+
+}

--- a/app/src/test/java/github/dev_playground/jeju_road/domain/usecase/GetRestaurantDetailUseCaseTest.kt
+++ b/app/src/test/java/github/dev_playground/jeju_road/domain/usecase/GetRestaurantDetailUseCaseTest.kt
@@ -6,11 +6,11 @@ import github.dev_playground.jeju_road.data.model.RestaurantDetail
 import github.dev_playground.jeju_road.data.model.ServingTimeData
 import github.dev_playground.jeju_road.data.repository.RestaurantRepository
 import github.dev_playground.jeju_road.util.Result
-import junit.framework.Assert
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
 import org.hamcrest.core.IsInstanceOf
+import org.junit.Assert
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever

--- a/app/src/test/java/github/dev_playground/jeju_road/domain/usecase/GetRestaurantListUseCaseTest.kt
+++ b/app/src/test/java/github/dev_playground/jeju_road/domain/usecase/GetRestaurantListUseCaseTest.kt
@@ -2,14 +2,14 @@ package github.dev_playground.jeju_road.domain.usecase
 
 import github.dev_playground.jeju_road.data.model.Content
 import github.dev_playground.jeju_road.data.model.Information
-import github.dev_playground.jeju_road.data.model.Restaurants
+import github.dev_playground.jeju_road.data.model.Restaurant
 import github.dev_playground.jeju_road.data.repository.RestaurantRepository
 import github.dev_playground.jeju_road.util.Result
-import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsInstanceOf
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -18,7 +18,7 @@ class GetRestaurantListUseCaseTest: BaseUseCaseTest() {
 
     private val repository : RestaurantRepository = mock()
     private var pageIndex = 0
-    private val restaurantData = Restaurants(
+    private val restaurantData = Restaurant(
         message = "test",
         information = Information(
             contentList = listOf(


### PR DESCRIPTION
## 문제 원인
- 화면 회전 시 데이터가 날아감
- 1. 프래그먼트 태그를 사용하여 프래그먼트 자체를 보존하기 & `sharedViewModel`을 사용하여 데이터 유지시키기 두 가지 방법으로 뷰모델의 데이터는 유지할 수 있으나(전자는 프래그먼트 보존, 후자는 뷰모델 보존), 두 가지 방법 모두 화면이 회전함에 따라 onViewCreated를 새로 타게 됨. 그러므로 `onViewCreated`에 존재하는 로직 모두가 재시작되고 `RecyclerView`의 `Adapter`도 새로 붙게 됨.  
- 2. `SwipeRefreshLayout`를 사용하고 있을 때 스와이프하면 하는 동시에 내부 `RecyclerView`의 `ScrollLisenter`가 반응하고, 스와이프가 끝나고 새로운 리스트가 추가된 이후에도 `ScrollListener`가 반응하여 데이터 로드가 2번 불리는 현상이 발생

## 해결 방법
- 1. `RecyclerView`에 보내는 리스트를 뷰모델의 `LiveData`로 보존하고, 새로운 데이터를 읽어오면 해당 `LiveData`에 추가하는 방식으로 데이터 리스트를 유지함.
- 2. `ScrollListener` 내부 `if`문에 `SwipeRefreshLayout.isRefreshing` 조건을 추가하여 방어함.

## 기타
- `page` 변수 관리를 위해 `Pager` 클래스 구현
- `Restaurants`가 아닌 `Restaurant`가 맞기에 이름 수정
- UI 화면에선 `Restaurant` 객체가 아닌 `List<Content>`가 필요하기 때문에 필요한 데이터만 전달하도록 뷰모델에 `restaurantState`, `contentList` 라이브데이터를 두고 UI단에서 `State`에 따라 데이터가 주입되도록 수정 (추후 에러화면이 추가되거나 로드에 실패할 때의 처리가 필요할 수도 있으므로 `UiState` 라이브데이터와 필요한 데이터를 가지는 라이브데이터를 분리하는게 옳다.)